### PR TITLE
Fix typo in Registrator section

### DIFF
--- a/content/documentation/0.4.x/api/registrator.html
+++ b/content/documentation/0.4.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/0.5.x/api/registrator.html
+++ b/content/documentation/0.5.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/0.6.x/api/registrator.html
+++ b/content/documentation/0.6.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/0.7.x/api/registrator.html
+++ b/content/documentation/0.7.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/1.0.x/api/registrator.html
+++ b/content/documentation/1.0.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/2.0.x/api/registrator.html
+++ b/content/documentation/2.0.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.0.x/api/registrator.html
+++ b/content/documentation/3.0.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.1.x/api/registrator.html
+++ b/content/documentation/3.1.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.10.x/api/registrator.html
+++ b/content/documentation/3.10.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.2.x/api/registrator.html
+++ b/content/documentation/3.2.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.3.x/api/registrator.html
+++ b/content/documentation/3.3.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.4.x/api/registrator.html
+++ b/content/documentation/3.4.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.5.x/api/registrator.html
+++ b/content/documentation/3.5.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.6.x/api/registrator.html
+++ b/content/documentation/3.6.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.7.x/api/registrator.html
+++ b/content/documentation/3.7.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.8.x/api/registrator.html
+++ b/content/documentation/3.8.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END

--- a/content/documentation/3.9.x/api/registrator.html
+++ b/content/documentation/3.9.x/api/registrator.html
@@ -45,14 +45,14 @@ Append custom header params into the Contact header of every REGISTER / un-REGIS
 h4. Parameters
 
 <%= my_lib_api_parameters({
-  "extraContactParams" => "@Object@ with keys representing the header param name and values represenging their param values. Set it to @null@ to remove them."
+  "extraContactParams" => "@Object@ with keys representing the header param name and values representing their param values. Set it to @null@ to remove them."
 }) %>
 
 CODE_BEGIN "javascript"
-ua.registrator.setExtraContactParams([
+ua.registrator.setExtraContactParams({
   x-vendor: 'FooBar',
   verified: true
-]);
+});
 
 // =>  ;x-vendor=FooBar;x-verified
 CODE_END


### PR DESCRIPTION

- Fix a typo for `representing`
- Fix the `ua.registrator.setExtraContactParams` method parameter from `Array` to `Object`