### PR TITLE
Modern browsers return DOMException

### DIFF
--- a/content/documentation/3.0.x/api/session.html
+++ b/content/documentation/3.0.x/api/session.html
@@ -788,24 +788,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.1.x/api/session.html
+++ b/content/documentation/3.1.x/api/session.html
@@ -788,24 +788,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.10.x/api/session.html
+++ b/content/documentation/3.10.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.2.x/api/session.html
+++ b/content/documentation/3.2.x/api/session.html
@@ -804,24 +804,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.3.x/api/session.html
+++ b/content/documentation/3.3.x/api/session.html
@@ -797,24 +797,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.4.x/api/session.html
+++ b/content/documentation/3.4.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.5.x/api/session.html
+++ b/content/documentation/3.5.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.6.x/api/session.html
+++ b/content/documentation/3.6.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.7.x/api/session.html
+++ b/content/documentation/3.7.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.8.x/api/session.html
+++ b/content/documentation/3.8.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.

--- a/content/documentation/3.9.x/api/session.html
+++ b/content/documentation/3.9.x/api/session.html
@@ -808,24 +808,24 @@ h4. Event @data@ fields
 
 h3(#event_getusermediafailed). getusermediafailed
 
-Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @getUserMedia()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createofferfailed). peerconnection:createofferfailed
 
-Fired when an internal call to @createOffer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createOffer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_createanswerfailed). peerconnection:createanswerfailed
 
-Fired when an internal call to @createAnswer()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @createAnswer()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setlocaldescriptionfailed). peerconnection:setlocaldescriptionfailed
 
-Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setLocalDescription()@ fails. It provides the @DOMException@ as argument.
 
 
 h3(#event_peerconnection_setremotedescriptionfailed). peerconnection:setremotedescriptionfailed
 
-Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMError@ as argument.
+Fired when an internal call to @setRemoteDescription()@ fails. It provides the @DOMException@ as argument.


### PR DESCRIPTION
`DOMError` is deprecated.

AFAICT modern browsers return `DOMException` on failure. The `DOMError` interface only defines the properties `name` and `message`, so it is a subset of `DOMException`.

https://developer.mozilla.org/en-US/docs/Web/API/DOMError
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createAnswer
